### PR TITLE
Multiplatform build fix

### DIFF
--- a/Source/Swag.Doc.Path.pas
+++ b/Source/Swag.Doc.Path.pas
@@ -24,8 +24,7 @@ unit Swag.Doc.Path;
 
 interface
 
-uses
-  WinApi.Windows,
+uses  
   System.Classes,
   System.Generics.Collections,
   System.RegularExpressions,


### PR DESCRIPTION
Removed reference to unit Winapi.Windows that was not needed and prevented compilation on platforms other than Windows.